### PR TITLE
Ncov counts

### DIFF
--- a/.github/workflows/update-ncov-case-counts.yaml
+++ b/.github/workflows/update-ncov-case-counts.yaml
@@ -15,6 +15,9 @@ on:
 jobs:
   case_counts:
     runs-on: ubuntu-latest
+    env:
+      SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+      SLACK_CHANNELS: ${{ github.event.inputs.slack_channel || 'nextstrain-counts-updates' }}
     defaults:
       run:
         # Login shell is required to include changes by conda init bash.
@@ -37,6 +40,10 @@ jobs:
         ./bin/fetch-ncov-global-case-counts > global_case_counts.tsv
         ./bin/fetch-ncov-us-case-counts > us_case_counts.tsv
 
+    - name: notify new us locations
+      run: |
+        ./bin/notify-on-new-location us_case_counts.tsv source-data/us-states.tsv
+
     - name: upload to S3
       run: |
         S3_DSTS=(
@@ -57,6 +64,4 @@ jobs:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-        SLACK_CHANNELS: ${{ github.event.inputs.slack_channel || 'nextstrain-counts-updates' }}
         TRIAL_NAME: ${{ github.event.inputs.trial_name }}

--- a/.github/workflows/update-ncov-case-counts.yaml
+++ b/.github/workflows/update-ncov-case-counts.yaml
@@ -10,7 +10,7 @@ on:
         required: false
       trial_name:
         description: 'Short name for a trial run. WARNING: without this we will overwrite files in s3://nextstrain-data/files/ncov/open/counts/'
-        requird: false
+        required: false
 
 jobs:
   case_counts:

--- a/.github/workflows/update-ncov-case-counts.yaml
+++ b/.github/workflows/update-ncov-case-counts.yaml
@@ -1,0 +1,56 @@
+name: COVID-19 case counts
+
+on:
+  schedule:
+    - cron: '0 16 * * *'
+  workflow_dispatch:
+    inputs:
+      slack_channel:
+        description: 'Slack channel to push update alerts. Default channel is nextstrain-counts-updates.'
+        required: false
+      trial_name:
+        description: 'Short name for a trial run. WARNING: without this we will overwrite files in s3://nextstrain-data/files/ncov/open/counts/'
+        requird: false
+
+jobs:
+  case_counts:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        # Login shell is required to include changes by conda init bash.
+        shell: bash -l -eo pipefail {0}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        python-version: 3.9
+        mamba-version: "*"
+        channels: conda-forge,bioconda
+        channel-priority: true
+        activate-environment: counts
+
+    - name: setup
+      run: mamba install "csvtk>=0.23.0"
+
+    - name: download case counts
+      run: |
+        ./bin/fetch-ncov-global-case-counts > global_case_counts.tsv
+        ./bin/fetch-ncov-us-case-counts > us_case_counts.tsv
+
+    - name: upload to S3
+      run: |
+        S3_DST=s3://nextstrain-data/files/ncov/open/counts
+
+        if [[ "$TRIAL_NAME" ]]; then
+          S3_DST+=/trial/"$TRIAL_NAME"
+        fi
+
+        ./bin/upload-to-s3 global_case_counts.tsv "$S3_DST"/global/cases.tsv.gz
+        ./bin/upload-to-s3 us_case_counts.tsv "$S3_DST"/usa/cases.tsv.gz
+      env:
+        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+        SLACK_CHANNELS: ${{ github.event.inputs.slack_channel || 'nextstrain-counts-updates' }}
+        TRIAL_NAME: ${{ github.event.inputs.trial_name }}

--- a/.github/workflows/update-ncov-case-counts.yaml
+++ b/.github/workflows/update-ncov-case-counts.yaml
@@ -39,14 +39,20 @@ jobs:
 
     - name: upload to S3
       run: |
-        S3_DST=s3://nextstrain-data/files/ncov/open/counts
+        S3_DSTS=(
+          s3://nextstrain-data/files/ncov/open/counts
+          s3://nextstrain-ncov-private/counts
+        )
 
-        if [[ "$TRIAL_NAME" ]]; then
-          S3_DST+=/trial/"$TRIAL_NAME"
-        fi
+        for S3_DST in ${S3_DSTS[@]}; do
 
-        ./bin/upload-to-s3 global_case_counts.tsv "$S3_DST"/global/cases.tsv.gz
-        ./bin/upload-to-s3 us_case_counts.tsv "$S3_DST"/usa/cases.tsv.gz
+          if [[ "$TRIAL_NAME" ]]; then
+            S3_DST+=/trial/"$TRIAL_NAME"
+          fi
+
+          ./bin/upload-to-s3 global_case_counts.tsv "$S3_DST"/global/cases.tsv.gz
+          ./bin/upload-to-s3 us_case_counts.tsv "$S3_DST"/usa/cases.tsv.gz
+        done
       env:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/update-ncov-gisaid-clade-counts.yaml
+++ b/.github/workflows/update-ncov-gisaid-clade-counts.yaml
@@ -12,7 +12,7 @@ on:
         required: false
       trial_name:
         description: 'Short name for a trial run. WARNING: without this we will overwrite files in s3://nextstrain-ncov-private/counts/'
-        requird: false
+        required: false
 
 jobs:
   gisaid_clade_counts:

--- a/.github/workflows/update-ncov-gisaid-clade-counts.yaml
+++ b/.github/workflows/update-ncov-gisaid-clade-counts.yaml
@@ -1,0 +1,79 @@
+name: GISAID SARS-CoV-2 clade counts
+
+on:
+  repository_dispatch:
+    types:
+      - clade-counts
+      - gisaid/clade-counts
+  workflow_dispatch:
+    inputs:
+      slack_channel:
+        description: 'Slack channel to push update alerts. Default channel is nextstrain-counts-updates.'
+        required: false
+      trial_name:
+        description: 'Short name for a trial run. WARNING: without this we will overwrite files in s3://nextstrain-ncov-private/counts/'
+        requird: false
+
+jobs:
+  gisaid_clade_counts:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        # Login shell is required to include changes by conda init bash.
+        shell: bash -l -eo pipefail {0}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        python-version: 3.9
+        mamba-version: "*"
+        channels: conda-forge,bioconda
+        channel-priority: true
+        activate-environment: counts
+
+    - name: setup
+      run: mamba install "pandas>=1.0.0"
+
+    - name: download metadata
+      run: ./bin/download-from-s3 s3://nextstrain-ncov-private/metadata.tsv.gz metadata.tsv
+      env:
+        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    - name: summarize global clade counts
+      run: |
+        ./bin/summarize-clade-sequence-counts \
+          --metadata metadata.tsv \
+          --clade-column Nextstrain_clade \
+          --filter-columns QC_overall_status \
+          --filter-query "QC_overall_status != 'bad'" \
+          --output global_clade_counts.tsv
+
+    - name: summarize us clade counts
+      run: |
+        ./bin/summarize-clade-sequence-counts \
+          --metadata metadata.tsv \
+          --location-column division \
+          --clade-column Nextstrain_clade \
+          --filter-columns QC_overall_status country \
+          --filter-query "QC_overall_status != 'bad' & country == 'USA'" \
+          --output us_clade_counts.tsv
+
+    - name: upload clade counts
+      run: |
+        S3_DST=s3://nextstrain-ncov-private/counts
+
+        if [[ "$TRIAL_NAME" ]]; then
+          S3_DST+=/trial/"$TRIAL_NAME"
+        fi
+
+        ./bin/upload-to-s3 global_clade_counts.tsv "$S3_DST"/global/nextstrain_clades.tsv.gz
+        ./bin/upload-to-s3 us_clade_counts.tsv "$S3_DST"/usa/nextstrain_clades.tsv.gz
+      env:
+        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+        SLACK_CHANNELS: ${{ github.event.inputs.slack_channel || 'nextstrain-counts-updates' }}
+        TRIAL_NAME: ${{ github.event.inputs.trial_name }}

--- a/.github/workflows/update-ncov-gisaid-clade-counts.yaml
+++ b/.github/workflows/update-ncov-gisaid-clade-counts.yaml
@@ -32,7 +32,7 @@ jobs:
         activate-environment: counts
 
     - name: setup
-      run: mamba install "pandas>=1.0.0"
+      run: mamba install "pandas>=1.0.0" "tsv-utils"
 
     - name: download metadata
       run: ./bin/download-from-s3 s3://nextstrain-ncov-private/metadata.tsv.gz metadata.tsv
@@ -40,6 +40,14 @@ jobs:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    - name: subset metadata columns
+      run: |
+        tsv-select -H \
+          -f strain,date,country,division,QC_overall_status,Nextstrain_clade \
+          metadata.tsv > metadata_pruned.tsv
+
+        mv metadata_pruned.tsv metadata.tsv
 
     - name: summarize global clade counts
       run: |

--- a/.github/workflows/update-ncov-open-clade-counts.yaml
+++ b/.github/workflows/update-ncov-open-clade-counts.yaml
@@ -1,0 +1,79 @@
+name: Open SARS-CoV-2 clade counts
+
+on:
+  repository_dispatch:
+    types:
+      - clade-counts
+      - open/clade-counts
+  workflow_dispatch:
+    inputs:
+      slack_channel:
+        description: 'Slack channel to push update alerts. Default channel is nextstrain-counts-updates.'
+        required: false
+      trial_name:
+        description: 'Short name for a trial run. WARNING: without this we will overwrite files in s3://nextstrain-data/files/ncov/open/counts/'
+        requird: false
+
+jobs:
+  open_clade_counts:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        # Login shell is required to include changes by conda init bash.
+        shell: bash -l -eo pipefail {0}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        python-version: 3.9
+        mamba-version: "*"
+        channels: conda-forge,bioconda
+        channel-priority: true
+        activate-environment: counts
+
+    - name: setup
+      run: mamba install "pandas>=1.0.0"
+
+    - name: download metadata
+      run: ./bin/download-from-s3 s3://nextstrain-data/files/ncov/open/metadata.tsv.gz metadata.tsv
+      env:
+        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    - name: summarize global clade counts
+      run: |
+        ./bin/summarize-clade-sequence-counts \
+          --metadata metadata.tsv \
+          --clade-column Nextstrain_clade \
+          --filter-columns QC_overall_status \
+          --filter-query "QC_overall_status != 'bad'" \
+          --output global_clade_counts.tsv
+
+    - name: summarize us clade counts
+      run: |
+        ./bin/summarize-clade-sequence-counts \
+          --metadata metadata.tsv \
+          --location-column division \
+          --clade-column Nextstrain_clade \
+          --filter-columns QC_overall_status country \
+          --filter-query "QC_overall_status != 'bad' & country == 'USA'" \
+          --output us_clade_counts.tsv
+
+    - name: upload clade counts
+      run: |
+        S3_DST=s3://nextstrain-data/files/ncov/open/counts
+
+        if [[ "$TRIAL_NAME" ]]; then
+          S3_DST+=/trial/"$TRIAL_NAME"
+        fi
+
+        ./bin/upload-to-s3 global_clade_counts.tsv "$S3_DST"/global/nextstrain_clades.tsv.gz
+        ./bin/upload-to-s3 us_clade_counts.tsv "$S3_DST"/usa/nextstrain_clades.tsv.gz
+      env:
+        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+        SLACK_CHANNELS: ${{ github.event.inputs.slack_channel || 'nextstrain-counts-updates' }}
+        TRIAL_NAME: ${{ github.event.inputs.trial_name }}

--- a/.github/workflows/update-ncov-open-clade-counts.yaml
+++ b/.github/workflows/update-ncov-open-clade-counts.yaml
@@ -33,7 +33,7 @@ jobs:
         activate-environment: counts
 
     - name: setup
-      run: mamba install "pandas>=1.0.0"
+      run: mamba install "pandas>=1.0.0" "tsv-utils"
 
     - name: download metadata
       run: ./bin/download-from-s3 s3://nextstrain-data/files/ncov/open/metadata.tsv.gz metadata.tsv
@@ -41,6 +41,14 @@ jobs:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    - name: subset metadata columns
+      run: |
+        tsv-select -H \
+          -f strain,date,country,division,QC_overall_status,Nextstrain_clade \
+          metadata.tsv > metadata_pruned.tsv
+
+        mv metadata_pruned.tsv metadata.tsv
 
     - name: summarize global clade counts
       run: |

--- a/.github/workflows/update-ncov-open-clade-counts.yaml
+++ b/.github/workflows/update-ncov-open-clade-counts.yaml
@@ -13,7 +13,7 @@ on:
         required: false
       trial_name:
         description: 'Short name for a trial run. WARNING: without this we will overwrite files in s3://nextstrain-data/files/ncov/open/counts/'
-        requird: false
+        required: false
 
 jobs:
   open_clade_counts:

--- a/.github/workflows/update-ncov-open-clade-counts.yaml
+++ b/.github/workflows/update-ncov-open-clade-counts.yaml
@@ -5,6 +5,7 @@ on:
     types:
       - clade-counts
       - open/clade-counts
+      - genbank/clade-counts
   workflow_dispatch:
     inputs:
       slack_channel:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 # Nextstrain Counts
 
 Internal tooling for the Nextstrain team to curate and standardize various counts data such as COVID-19 case counts and SARS-CoV-2 clade sequence counts.
+
+## Data Sources
+
+- Global COVID-19 case counts: [Our World in Data](https://covid.ourworldindata.org/data/owid-covid-data.csv), originally from [JHU CSSE COVID-19 Data](https://github.com/CSSEGISandData/COVID-19)
+- USA state COVID-19 case counts: [United States COVID-19 Cases and Deaths by State over Time](https://data.cdc.gov/Case-Surveillance/United-States-COVID-19-Cases-and-Deaths-by-State-o/9mfq-cb36)
+- SARS-CoV-2 sequences: Nextstrain-curated metadata TSVs for GISAID and GenBank produced by [nextstrain/ncov-ingest](https://github.com/nextstrain/ncov-ingest)
+## Running locally
+
+1. Create a conda environment named `nextstrain-counts`
+```
+mamba create -n nextstrain-counts -c bioconda "csvtk>=0.23.0" "pandas>=1.0.0" --yes
+```
+2. Activate the conda environment
+```
+conda activate nextstrain-counts
+```

--- a/README.md
+++ b/README.md
@@ -7,6 +7,27 @@ Internal tooling for the Nextstrain team to curate and standardize various count
 - Global COVID-19 case counts: [Our World in Data](https://covid.ourworldindata.org/data/owid-covid-data.csv), originally from [JHU CSSE COVID-19 Data](https://github.com/CSSEGISandData/COVID-19)
 - USA state COVID-19 case counts: [United States COVID-19 Cases and Deaths by State over Time](https://data.cdc.gov/Case-Surveillance/United-States-COVID-19-Cases-and-Deaths-by-State-o/9mfq-cb36)
 - SARS-CoV-2 sequences: Nextstrain-curated metadata TSVs for GISAID and GenBank produced by [nextstrain/ncov-ingest](https://github.com/nextstrain/ncov-ingest)
+
+## Outputs
+
+This repository produces multiple TSVs that are routinely uploaded to AWS S3 buckets.
+
+The GISAID data is stored at `s3://nextstrain-ncov-private/counts/` and is not publicly available.
+The open (GenBank) data is stored at `s3://nextstrain-data/files/ncov/open/counts/` and is publicly available.
+
+Within `counts/`, files are organized by geographic resolution and count type.
+Within TSVs at the global resolution, the `location` column contains countries.
+Within TSVs at the country resolution, the `location` column contains divisions (e.g. states for US).
+
+### Summary of Available open (GenBank) files
+
+| Geographic Resolution  | Type | Address |
+| --- | --- | --- |
+| Global | Cases | https://data.nextstrain.org/files/ncov/open/counts/global/cases.tsv.gz |
+|        | Nextstrain clades | https://data.nextstrain.org/files/ncov/open/counts/global/nextstrain_clades.tsv.gz |
+| USA    | Cases | https://data.nextstrain.org/files/ncov/open/counts/usa/cases.tsv.gz |
+|        | Nextstrain clades | https://data.nextstrain.org/files/ncov/open/counts/usa/nextstrain_clades.tsv.gz |
+
 ## Running locally
 
 1. Create a conda environment named `nextstrain-counts`

--- a/bin/download-from-s3
+++ b/bin/download-from-s3
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+
+bin="$(dirname "$0")"
+
+main() {
+    local src="${1:?A source s3:// URL is required as the first argument.}"
+    local dst="${2:?A destination file path is required as the second argument.}"
+
+    local s3path="${src#s3://}"
+    local bucket="${s3path%%/*}"
+    local key="${s3path#*/}"
+
+    local src_hash dst_hash no_hash=0000000000000000000000000000000000000000000000000000000000000000
+    dst_hash="$("$bin/sha256sum" < "$dst" || true)"
+    src_hash="$(aws s3api head-object --bucket "$bucket" --key "$key" --query Metadata.sha256sum --output text 2>/dev/null || echo "$no_hash")"
+
+    echo "[ INFO] Downloading $src → $dst"
+    if [[ $src_hash != "$dst_hash" ]]; then
+        aws s3 cp --no-progress "$src" - |
+        if [[ "$src" == *.gz ]]; then
+            gunzip -cfq
+        elif  [[ "$src" == *.xz ]]; then
+            xz -T0 -dcq
+        else
+            cat
+        fi > "$dst"
+    else
+        echo "[ INFO] Files are identical, skipping download"
+    fi
+}
+
+main "$@"

--- a/bin/fetch-ncov-global-case-counts
+++ b/bin/fetch-ncov-global-case-counts
@@ -13,5 +13,7 @@ curl https://covid.ourworldindata.org/data/owid-covid-data.csv \
     csvtk filter -f "cases>0" |
     # Remove decimals from case counts
     csvtk round -f cases -n 0 |
+    # Replace "United States" with "USA" to match ncov metadata
+    csvtk replace -f location -p 'United States' -r 'USA' |
     # Convert to TSV
     csvtk csv2tab

--- a/bin/fetch-ncov-global-case-counts
+++ b/bin/fetch-ncov-global-case-counts
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+# Fetch CSV from Our World in Data
+curl https://covid.ourworldindata.org/data/owid-covid-data.csv \
+    --fail --silent --show-error \
+    --header 'User-Agent: https://github.com/nextstrain/counts (hello@nextstrain.org)' |
+    # Only keep the date, location, and new_cases columns
+    csvtk cut -f date,location,new_cases |
+    # Rename new_cases to cases
+    csvtk rename -f new_cases -n cases |
+    # Only keep rows that have more than 0 cases
+    csvtk filter -f "cases>0" |
+    # Remove decimals from case counts
+    csvtk round -f cases -n 0 |
+    # Convert to TSV
+    csvtk csv2tab

--- a/bin/fetch-ncov-global-case-counts
+++ b/bin/fetch-ncov-global-case-counts
@@ -6,7 +6,7 @@ curl https://covid.ourworldindata.org/data/owid-covid-data.csv \
     --fail --silent --show-error \
     --header 'User-Agent: https://github.com/nextstrain/counts (hello@nextstrain.org)' |
     # Only keep the date, location, and new_cases columns
-    csvtk cut -f date,location,new_cases |
+    csvtk cut -f location,date,new_cases |
     # Rename new_cases to cases
     csvtk rename -f new_cases -n cases |
     # Only keep rows that have more than 0 cases
@@ -15,5 +15,7 @@ curl https://covid.ourworldindata.org/data/owid-covid-data.csv \
     csvtk round -f cases -n 0 |
     # Replace "United States" with "USA" to match ncov metadata
     csvtk replace -f location -p 'United States' -r 'USA' |
+    # Sort by location then date
+    csvtk sort -k location,date |
     # Convert to TSV
     csvtk csv2tab

--- a/bin/fetch-ncov-us-case-counts
+++ b/bin/fetch-ncov-us-case-counts
@@ -4,10 +4,19 @@ set -euo pipefail
 bin="$(dirname "$0")"
 base="$(realpath --relative-to . "$bin/..")"
 
+# Fetch total count of records from Socrata OpenData API for CDC dataset 9mfq-cb36
+# to set as the fetch limit in the API call below
+total_count=$(
+    curl 'https://data.cdc.gov/resource/9mfq-cb36.json?$select=count(*)' \
+        --fail --silent --show-error \
+        --header 'User-Agent: https://github.com/nextstrain/counts (hello@nextstrain.org)' |
+        jq --raw-output .[].count
+)
+
 # Fetch CSV from Socrata Open Data API for CDC dataset 9mfq-cb36
 # Only includes the submission_date, state, and new_cases columns
 # Only keeps rows that have more than 0 cases
-curl 'https://data.cdc.gov/resource/9mfq-cb36.csv?$select=submission_date,state,new_case&$where=new_case>0' \
+curl 'https://data.cdc.gov/resource/9mfq-cb36.csv?$select=submission_date,state,new_case&$where=new_case>0&$limit='+$total_count \
     --fail --silent --show-error \
     --header 'User-Agent: https://github.com/nextstrain/counts (hello@nextstrain.org)' |
     # Rename columns

--- a/bin/fetch-ncov-us-case-counts
+++ b/bin/fetch-ncov-us-case-counts
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+bin="$(dirname "$0")"
+base="$(realpath --relative-to . "$bin/..")"
+
+# Fetch CSV from Socrata Open Data API for CDC dataset 9mfq-cb36
+# Only includes the submission_date, state, and new_cases columns
+# Only keeps rows that have more than 0 cases
+curl 'https://data.cdc.gov/resource/9mfq-cb36.csv?$select=submission_date,state,new_case&$where=new_case>0' \
+    --fail --silent --show-error \
+    --header 'User-Agent: https://github.com/nextstrain/counts (hello@nextstrain.org)' |
+    # Rename columns
+    csvtk rename -f submission_date,state,new_case -n date,location,cases |
+    # Replace state abbreviations with full name
+    csvtk replace -f location -p '([A-Z]{2,3})' -k $base/source-data/us-states.tsv -r '{kv}' --keep-key |
+    # Remove time stamp from date column
+    csvtk replace -f date -p '([\d]{4}-[\d]{2}-[\d]{2})(.+)' -r '$1' |
+    # Remove decimals from case counts
+    csvtk round -f cases -n 0 |
+    # Convert to TSV
+    csvtk csv2tab

--- a/bin/fetch-ncov-us-case-counts
+++ b/bin/fetch-ncov-us-case-counts
@@ -19,13 +19,13 @@ total_count=$(
 curl 'https://data.cdc.gov/resource/9mfq-cb36.csv?$select=submission_date,state,new_case&$where=new_case>0&$limit='+$total_count \
     --fail --silent --show-error \
     --header 'User-Agent: https://github.com/nextstrain/counts (hello@nextstrain.org)' |
-    # Rename columns
-    csvtk rename -f submission_date,state,new_case -n date,location,cases |
     # Replace state abbreviations with full name
-    csvtk replace -f location -p '([A-Z]{2,3})' -k $base/source-data/us-states.tsv -r '{kv}' --keep-key |
+    csvtk replace -f state -p '([A-Z]{2,3})' -k $base/source-data/us-states.tsv -r '{kv}' --keep-key |
+    # Sum case counts grouped by date and state - added to sum separate case counts for NYC and NY state
+    csvtk summary -n 0 -f new_case:sum -g submission_date,state |
+    # Rename columns
+    csvtk rename -f submission_date,state,new_case:sum -n date,location,cases |
     # Remove time stamp from date column
     csvtk replace -f date -p '([\d]{4}-[\d]{2}-[\d]{2})(.+)' -r '$1' |
-    # Remove decimals from case counts
-    csvtk round -f cases -n 0 |
     # Convert to TSV
     csvtk csv2tab

--- a/bin/fetch-ncov-us-case-counts
+++ b/bin/fetch-ncov-us-case-counts
@@ -16,16 +16,18 @@ total_count=$(
 # Fetch CSV from Socrata Open Data API for CDC dataset 9mfq-cb36
 # Only includes the submission_date, state, and new_cases columns
 # Only keeps rows that have more than 0 cases
-curl 'https://data.cdc.gov/resource/9mfq-cb36.csv?$select=submission_date,state,new_case&$where=new_case>0&$limit='+$total_count \
+curl 'https://data.cdc.gov/resource/9mfq-cb36.csv?$select=state,submission_date,new_case&$where=new_case>0&$limit='+$total_count \
     --fail --silent --show-error \
     --header 'User-Agent: https://github.com/nextstrain/counts (hello@nextstrain.org)' |
     # Replace state abbreviations with full name
     csvtk replace -f state -p '([A-Z]{2,3})' -k $base/source-data/us-states.tsv -r '{kv}' --keep-key |
     # Sum case counts grouped by date and state - added to sum separate case counts for NYC and NY state
-    csvtk summary -n 0 -f new_case:sum -g submission_date,state |
+    csvtk summary -n 0 -f new_case:sum -g state,submission_date |
     # Rename columns
-    csvtk rename -f submission_date,state,new_case:sum -n date,location,cases |
+    csvtk rename -f state,submission_date,new_case:sum -n location,date,cases |
     # Remove time stamp from date column
     csvtk replace -f date -p '([\d]{4}-[\d]{2}-[\d]{2})(.+)' -r '$1' |
+    # Sort by location then date
+    csvtk sort -k location,date |
     # Convert to TSV
     csvtk csv2tab

--- a/bin/notify-on-new-location
+++ b/bin/notify-on-new-location
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -euo pipefail
+
+: "${SLACK_TOKEN:?The SLACK_TOKEN environment variable is required.}"
+: "${SLACK_CHANNELS:?The SLACK_CHANNELS environment variable is required.}"
+
+bin="$(dirname "$0")"
+
+new_locations="${1:?A TSV file to check for new entries in the 'location' column is required as the first argument.}"
+existing_locations="${2:?A TSV file with known locations listed in the 'name' column is required as the second argument.}"
+
+diff="$(mktemp -t new-locations-XXXXXX)"
+
+trap "rm -f '$diff'" EXIT
+
+get_unique_values() {
+    cat $1 |
+        # Subset to provided column name
+        csvtk cut -t -f $2 |
+        # Get unique values
+        csvtk uniq -f 1 |
+        # Sort values
+        csvtk sort -k 1 |
+        # Remove the column header
+        csvtk del-header
+}
+
+# Output values that are in the "location" column of $new_locations
+# but not the "name" column of $existing_locations
+comm -13 \
+    <(get_unique_values $existing_locations "name") \
+    <(get_unique_values $new_locations "location") \
+    > $diff
+
+# Send a Slack notification if there are new location values
+if [[ -s "$diff" ]]; then
+    echo "Notifying Slack about new locations."
+    "$bin"/notify-slack ":warning: Flagged new locations that need to be added to \`${existing_locations}\`"
+    "$bin"/notify-slack --upload "new-locations.txt" < "$diff"
+else
+    echo "No flagged location additions."
+fi

--- a/bin/notify-slack
+++ b/bin/notify-slack
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -euo pipefail
+
+: "${SLACK_TOKEN:?The SLACK_TOKEN environment variable is required.}"
+: "${SLACK_CHANNELS:?The SLACK_CHANNELS environment variable is required.}"
+
+upload=0
+args=()
+
+for arg; do
+    case "$arg" in
+        --upload)
+            upload=1;;
+        *)
+            args+=("$arg");;
+    esac
+done
+
+set -- "${args[@]}"
+
+text="${1:?Some message text is required.}"
+
+if [[ "$upload" == 1 ]]; then
+    echo "Uploading data to Slack with the message: $text"
+    curl https://slack.com/api/files.upload \
+        --header "Authorization: Bearer $SLACK_TOKEN" \
+        --form-string channels="$SLACK_CHANNELS" \
+        --form-string title="$text" \
+        --form-string filename="$text" \
+        --form file=@/dev/stdin \
+        --form filetype=text \
+        --fail --silent --show-error \
+        --http1.1 \
+        --output /dev/null
+else
+    echo "Posting Slack message: $text"
+    curl https://slack.com/api/chat.postMessage \
+        --header "Authorization: Bearer $SLACK_TOKEN" \
+        --form-string channel="$SLACK_CHANNELS" \
+        --form-string text="$text" \
+        --fail --silent --show-error \
+        --http1.1 \
+        --output /dev/null
+fi

--- a/bin/sha256sum
+++ b/bin/sha256sum
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""
+Portable sha256sum utility.
+"""
+from hashlib import sha256
+from sys import stdin
+
+chunk_size = 5 * 1024**2 # 5 MiB
+
+h = sha256()
+
+for chunk in iter(lambda: stdin.buffer.read(chunk_size), b""):
+    h.update(chunk)
+
+print(h.hexdigest())

--- a/bin/summarize-clade-sequence-counts
+++ b/bin/summarize-clade-sequence-counts
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+Summarize sequence counts grouped by date, location, and clade.
+"""
+import argparse
+import pandas as pd
+import sys
+
+from datetime import datetime
+
+
+def format_date(date_string, expected_format):
+    """
+    Format *date_string* to ISO 8601 date (YYYY-MM-DD).
+    If *date_string* does not match *expected_format*, return None.
+
+    >>> expected_format = '%Y-%m-%d'
+    >>> format_date("2020", expected_format)
+    None
+    >>> format_date("2020-01", expected_format)
+    None
+    >>> format_date("XXXX-XX-XX", expected_format)
+    None
+    >>> format_date("2020-1-15", expected_format)
+    '2020-01-15'
+    >>> format_date("2020-01-15", expected_format)
+    '2020-01-15'
+    """
+    try:
+        return datetime.strptime(date_string, expected_format).strftime('%Y-%m-%d')
+    except ValueError:
+        return None
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(__doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+    parser.add_argument("--metadata", required=True,
+        help="Path to metadata TSV that includes date, location, and clade information. " +
+             "Local and remote (HTTP, S3, etc.) paths are valid.")
+    parser.add_argument("--id-column", default="strain",
+        help="Column in metadata TSV with the sequence ID.")
+    parser.add_argument("--date-column", default="date",
+        help="Column in metadata TSV with date information. " +
+             "Dates are expected to be in ISO 8601 date format (i.e. YYYY-MM-DD). " +
+             "Rows with incorrect date format or ambiguous dates will be dropped.")
+    parser.add_argument("--location-column", default="country",
+        help="Column in metadata TSV with location information")
+    parser.add_argument("--clade-column", required=True,
+        help="Column in metadata TSV with clade information")
+    parser.add_argument("--filter-columns", nargs="+",
+        help="Columns that will be used in the `--filter-query` option. " +
+             "Must be provided if using the `--filter-query` option.")
+    parser.add_argument('--filter-query',
+        help="Filter sequences by attribute. " +
+             "Uses Pandas Dataframe querying, " +
+             "see https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query for syntax " +
+             """(e.g., --filter-query "country == 'USA'") """)
+    parser.add_argument("--metadata-chunk-size", type=int, default=100000,
+        help="Maximum metadata records to read into memory at once during initial pass." +
+             "Increasing this value increases peak memory usage.")
+    parser.add_argument("--output",
+        help="Path to output TSV for sequence counts per date, location, and clade.",)
+
+    args = parser.parse_args()
+
+    if args.filter_query and not args.filter_columns:
+        print("ERROR: Filter columns must be provided if using a filter query.",
+            file=sys.stderr)
+        sys.exit(1)
+
+    # Map of metadata columns to output columns
+    metadata_column_map = {
+        args.id_column: 'sequences',
+        args.date_column: 'date',
+        args.location_column: 'location',
+        args.clade_column: 'clade'
+    }
+
+    # Only use required columns, adding filter columns if provided
+    metadata_usecols = set(metadata_column_map.keys())
+    if args.filter_columns:
+        metadata_usecols.update(args.filter_columns)
+
+    # Load metadata TSV.
+    metadata_reader = pd.read_csv(
+        args.metadata,
+        sep = "\t",
+        usecols = metadata_usecols,
+        dtype = 'object',
+        chunksize=args.metadata_chunk_size,
+    )
+
+    # Iterate through metadata in chunks to control peak memory usage.
+    metadata_chunks = []
+    for metadata in metadata_reader:
+        # If provided filter query, apply query then subset to required columns
+        if args.filter_query:
+            try:
+                metadata.query(args.filter_query, inplace=True)
+            except Exception as e:
+                print(
+                    "ERROR: An error occurred when applying the filter query. "
+                    "Most likely the filter query used columns that were not included in the filter columns. "
+                    f"See detailed error: ({e})",
+                    file=sys.stderr)
+                sys.exit(1)
+
+            metadata = metadata[metadata_column_map.keys()]
+
+        # Rename columns to output column names
+        metadata.rename(columns=metadata_column_map, inplace=True)
+
+        # Convert location and clade columns to category dtype
+        metadata['location'] = metadata['location'].astype('category')
+        metadata['clade'] = metadata['clade'].astype('category')
+
+        # Convert date column to datetime, sets ambiguous dates to None
+        metadata['date'] = metadata['date'].apply(lambda x: format_date(x, '%Y-%m-%d'))
+
+        # Drop rows with null date, location, or clades
+        metadata.dropna(subset=['date', 'location', 'clade'], inplace=True)
+
+        metadata_chunks.append(metadata)
+
+    # Merge all chunks that passed all filters.
+    metadata = pd.concat(
+        metadata_chunks,
+        ignore_index=True,
+    )
+
+    # Count of sequences grouped by date, location, clade
+    counts_by_date_location_clade = metadata.groupby(
+        [
+            "date",
+            "location",
+            "clade",
+        ],
+        observed=True,
+        as_index=False,
+    )["sequences"].count().sort_values(["location", "clade", "date"])
+
+    counts_by_date_location_clade.to_csv(
+        args.output,
+        sep="\t",
+        index=False,
+    )
+

--- a/bin/summarize-clade-sequence-counts
+++ b/bin/summarize-clade-sequence-counts
@@ -133,9 +133,9 @@ if __name__ == '__main__':
     # Count of sequences grouped by date, location, clade
     counts_by_date_location_clade = metadata.groupby(
         [
-            "date",
             "location",
             "clade",
+            "date",
         ],
         observed=True,
         as_index=False,

--- a/bin/upload-to-s3
+++ b/bin/upload-to-s3
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -euo pipefail
+
+bin="$(dirname "$0")"
+
+main() {
+    local quiet=0
+
+    for arg; do
+        case "$arg" in
+            --quiet)
+                quiet=1
+                shift;;
+            *)
+                break;;
+        esac
+    done
+
+    local src="${1:?A source file is required as the first argument.}"
+    local dst="${2:?A destination s3:// URL is required as the second argument.}"
+
+    local s3path="${dst#s3://}"
+    local bucket="${s3path%%/*}"
+    local key="${s3path#*/}"
+
+    local src_hash dst_hash no_hash=0000000000000000000000000000000000000000000000000000000000000000
+    src_hash="$("$bin/sha256sum" < "$src")"
+    dst_hash="$(aws s3api head-object --bucket "$bucket" --key "$key" --query Metadata.sha256sum --output text 2>/dev/null || echo "$no_hash")"
+
+    if [[ $src_hash != "$dst_hash" ]]; then
+        echo "Uploading $src → $dst"
+        if [[ "$dst" == *.gz ]]; then
+            gzip -c "$src"
+        elif  [[ "$dst" == *.xz ]]; then
+            xz -2 -T0 -c "$src"
+        else
+            cat "$src"
+        fi | aws s3 cp --no-progress - "$dst" --metadata sha256sum="$src_hash" "$(content-type "$dst")"
+
+        if [[ $quiet == 1 ]]; then
+            echo "Quiet mode. No Slack notification sent."
+            exit 0
+        fi
+
+        if ! "$bin"/notify-slack "Updated $dst available."; then
+            echo "Notifying Slack failed, but exiting with success anyway."
+        fi
+    else
+        echo "Uploading $src → $dst: files are identical, skipping upload"
+    fi
+}
+
+content-type() {
+    case "$1" in
+        *.tsv)      echo --content-type=text/tab-separated-values;;
+        *.csv)      echo --content-type=text/comma-separated-values;;
+        *.ndjson)   echo --content-type=application/x-ndjson;;
+        *.gz)       echo --content-type=application/gzip;;
+        *.xz)       echo --content-type=application/x-xz;;
+        *)          echo --content-type=text/plain;;
+    esac
+}
+
+main "$@"

--- a/source-data/us-states.tsv
+++ b/source-data/us-states.tsv
@@ -1,0 +1,61 @@
+abbreviation	name
+AL	Alabama
+AK	Alaska
+AZ	Arizona
+AR	Arkansas
+CA	California
+CO	Colorado
+CT	Connecticut
+DE	Delaware
+DC	Washington DC
+FL	Florida
+GA	Georgia
+HI	Hawaii
+ID	Idaho
+IL	Illinois
+IN	Indiana
+IA	Iowa
+KS	Kansas
+KY	Kentucky
+LA	Louisiana
+ME	Maine
+MT	Montana
+NE	Nebraska
+NV	Nevada
+NH	New Hampshire
+NJ	New Jersey
+NM	New Mexico
+NYC	New York
+NY	New York
+NC	North Carolina
+ND	North Dakota
+OH	Ohio
+OK	Oklahoma
+OR	Oregon
+MD	Maryland
+MA	Massachusetts
+MI	Michigan
+MN	Minnesota
+MS	Mississippi
+MO	Missouri
+PA	Pennsylvania
+RI	Rhode Island
+SC	South Carolina
+SD	South Dakota
+TN	Tennessee
+TX	Texas
+UT	Utah
+VT	Vermont
+VA	Virginia
+WA	Washington
+WV	West Virginia
+WI	Wisconsin
+WY	Wyoming
+AS	American Samoa
+FSM	Federated States of Micronesia
+GU	Guam
+MP	Northern Mariana Islands
+PR	Puerto Rico
+PW	Republic of Palau
+RMI	Republic of the Marshall Islands
+VI	Virgin Islands

--- a/source-data/us-states.tsv
+++ b/source-data/us-states.tsv
@@ -1,61 +1,61 @@
 abbreviation	name
-AL	Alabama
 AK	Alaska
-AZ	Arizona
+AL	Alabama
 AR	Arkansas
+AS	American Samoa
+AZ	Arizona
 CA	California
 CO	Colorado
 CT	Connecticut
-DE	Delaware
 DC	Washington DC
+DE	Delaware
 FL	Florida
+FSM	Federated States of Micronesia
 GA	Georgia
+GU	Guam
 HI	Hawaii
+IA	Iowa
 ID	Idaho
 IL	Illinois
 IN	Indiana
-IA	Iowa
 KS	Kansas
 KY	Kentucky
 LA	Louisiana
+MA	Massachusetts
+MD	Maryland
 ME	Maine
+MI	Michigan
+MN	Minnesota
+MO	Missouri
+MP	Northern Mariana Islands
+MS	Mississippi
 MT	Montana
+NC	North Carolina
+ND	North Dakota
 NE	Nebraska
-NV	Nevada
 NH	New Hampshire
 NJ	New Jersey
 NM	New Mexico
-NYC	New York
+NV	Nevada
 NY	New York
-NC	North Carolina
-ND	North Dakota
+NYC	New York
 OH	Ohio
 OK	Oklahoma
 OR	Oregon
-MD	Maryland
-MA	Massachusetts
-MI	Michigan
-MN	Minnesota
-MS	Mississippi
-MO	Missouri
 PA	Pennsylvania
+PR	Puerto Rico
+PW	Republic of Palau
 RI	Rhode Island
+RMI	Republic of the Marshall Islands
 SC	South Carolina
 SD	South Dakota
 TN	Tennessee
 TX	Texas
 UT	Utah
-VT	Vermont
 VA	Virginia
-WA	Washington
-WV	West Virginia
-WI	Wisconsin
-WY	Wyoming
-AS	American Samoa
-FSM	Federated States of Micronesia
-GU	Guam
-MP	Northern Mariana Islands
-PR	Puerto Rico
-PW	Republic of Palau
-RMI	Republic of the Marshall Islands
 VI	Virgin Islands
+VT	Vermont
+WA	Washington
+WI	Wisconsin
+WV	West Virginia
+WY	Wyoming


### PR DESCRIPTION
First pass of the automated pipeline for ncov counts that has scripts run directly via GitHub Action workflows. 
The current pipeline does not seem complicated enough to warrant porting to Snakemake, but it would be helpful when we want to expand counts to other pathogens and/or other clade definitions. 